### PR TITLE
fix: Send output to existing directory

### DIFF
--- a/flooding/Sentinel2_Water_Extraction/Sentinel2_Water_Extraction.ipynb
+++ b/flooding/Sentinel2_Water_Extraction/Sentinel2_Water_Extraction.ipynb
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_directory = '/home/splanzer/projects/gisborne_flooding'"
+    "output_directory = 'out'"
    ]
   },
   {

--- a/flooding/Sentinel2_Water_Extraction/out/.gitignore
+++ b/flooding/Sentinel2_Water_Extraction/out/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore


### PR DESCRIPTION
But separate from source, to make sure it doesn't clutter the filesystem.