### PR TITLE
build: Bump nixpkgs

### DIFF
--- a/flooding/Sentinel2_Water_Extraction/bump-nixpkgs.bash
+++ b/flooding/Sentinel2_Water_Extraction/bump-nixpkgs.bash
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+shopt -s failglob inherit_errexit
+
+if [[ $# -ne 1 ]]; then
+    cat >&2 <<EOF
+bump-nixpkgs.bash: Update nixpkgs.json with latest info from given release
+
+Usage:
+
+./bump-nixpkgs.bash RELEASE
+
+Example:
+
+./bump-nixpkgs.bash 22.05
+    Bumps nixpkgs within the 22.05 release.
+EOF
+    exit 2
+fi
+
+release="$1"
+
+cleanup() {
+    rm --force --recursive "$working_dir"
+}
+trap cleanup EXIT
+working_dir="$(mktemp --directory)"
+
+release_file="${working_dir}/release.json"
+curl "https://api.github.com/repos/NixOS/nixpkgs/git/refs/heads/release-${release}" >"$release_file"
+commit_id="$(jq --raw-output .object.sha "$release_file")"
+commit_date="$(curl "https://api.github.com/repos/NixOS/nixpkgs/commits/$commit_id" | jq --raw-output '.commit.committer.date' | tr ':' '-')"
+
+partial_file="${working_dir}/nixpkgs-partial.json"
+jq --arg commit_date "$commit_date" --raw-output '{name: (.ref | split("/")[-1] + "-" + $commit_date), url: ("https://github.com/NixOS/nixpkgs/archive/" + .object.sha + ".tar.gz")}' "$release_file" >"$partial_file"
+
+archive_checksum="$(nix-prefetch-url --unpack "$(jq --raw-output .url "$partial_file")")"
+full_file="${working_dir}/nixpkgs.json"
+jq '. + {sha256: $hash}' --arg hash "$archive_checksum" "$partial_file" >"$full_file"
+
+target_file='./nixpkgs.json'
+if diff "$full_file" "$target_file"; then
+    echo "No change; aborting." >&2
+else
+    mv "$full_file" "$target_file"
+fi

--- a/flooding/Sentinel2_Water_Extraction/nixpkgs.json
+++ b/flooding/Sentinel2_Water_Extraction/nixpkgs.json
@@ -1,0 +1,5 @@
+{
+  "name": "release-22.05-2022-10-26T23-46-50Z",
+  "url": "https://github.com/NixOS/nixpkgs/archive/25e653e3e708fb56543ae055fd5d7c3977101b53.tar.gz",
+  "sha256": "06j9rbq0v2zq0daw4gxczbb7nhwl3gdfzagk7q9ip6xh3133qs3z"
+}

--- a/flooding/Sentinel2_Water_Extraction/shell.nix
+++ b/flooding/Sentinel2_Water_Extraction/shell.nix
@@ -1,10 +1,11 @@
 { pkgs ? import
     (
-      fetchTarball {
-        name = "22.05";
-        url = "https://github.com/NixOS/nixpkgs/archive/ce6aa13369b667ac2542593170993504932eb836.tar.gz";
-        sha256 = "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
-      })
+      fetchTarball (
+        builtins.fromJSON (
+          builtins.readFile ./nixpkgs.json
+        )
+      )
+    )
     { }
 }:
 let


### PR DESCRIPTION
Also introduce an easy way to bump it by simply running `./bump-nixpkgs.bash` to check for a new nixpkgs version, and update `nixpkgs.json` if so.