### PR TITLE
refactor: Remove implicit dependencies

### DIFF
--- a/flooding/Sentinel2_Water_Extraction/poetry.lock
+++ b/flooding/Sentinel2_Water_Extraction/poetry.lock
@@ -1529,7 +1529,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5569a443f6bfc1553c6648183220a5b354d75af65c08f1391562cd195e4752b9"
+content-hash = "6c00c0423308bd97f33c2d7090889657bc35f3351343a9e913336b291fb120b2"
 
 [metadata.files]
 affine = [

--- a/flooding/Sentinel2_Water_Extraction/pyproject.toml
+++ b/flooding/Sentinel2_Water_Extraction/pyproject.toml
@@ -11,11 +11,8 @@ gdal = "3.4.2"
 geopandas = "*"
 jupyter = "*"
 matplotlib = "*"
-numpy = "*"
-rasterio = "*"
 rio-tiler = "*"
 sat-search = "*"
-shapely = "*"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
These packages are all dependencies of other packages already in the dependency list, so their presence here is redundant.