### PR TITLE
feat: Auto-merge Dependabot pull requests

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,1 +1,7 @@
 version = 1
+
+[approve]
+auto_approve_usernames = ["dependabot"]
+
+[merge.automerge_dependencies]
+usernames = ["dependabot"]


### PR DESCRIPTION
Results in much less time wasted on manually dealing with Dependabot
PRs, at the risk of merging some breaking change if it's not detected by
our pipeline. It would be easy to revert, though, if any breaking change
is detected after the fact.
