### PR TITLE
chore: Remove pip upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,6 @@ jobs:
       - name: Update package registry
         run: sudo apt-get update
 
-      - name: Upgrade pip
-        run:
-          pip install --disable-pip-version-check --progress-bar=off --upgrade
-          pip
-
       - name: Install Poetry
         run: pip install --disable-pip-version-check --progress-bar=off poetry
 


### PR DESCRIPTION
It looks like all the Linux, macOS, and Windows runners already have up-to-date pip installed, so this step is probably redundant.