### PR TITLE
fix: Cancel only deploy jobs on master

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -12,10 +12,6 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -38,6 +34,9 @@ jobs:
     if:
       github.repository == 'linz/emergency-management-tools' && github.ref ==
       'refs/heads/master'
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Otherwise PRs clobber each others' build jobs.