### PR TITLE
fix: Downgrade Poetry below 1.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,9 +136,8 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install Conda environment packages
-        run:
-          conda install --channel=conda-forge --quiet --yes gdal=${{
-          env.GDAL_VERSION }} poetry
+        run: conda install --channel=conda-forge --quiet --yes gdal=${{
+          env.GDAL_VERSION }} poetry=1.3.2 # Workaround for https://github.com/python-poetry/poetry/issues/7589
 
       - name: Install Python packages on non-Windows runner
         run: poetry install --only=main --no-root


### PR DESCRIPTION
Poetry 1.4.0 is broken on Windows
<https://github.com/python-poetry/poetry/issues/7589>.