### PR TITLE
build: Use Poetry 1.7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,8 +153,9 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install Conda environment packages
-        run: conda install --channel=conda-forge --quiet --yes gdal=${{
-          env.GDAL_VERSION }} poetry=1.3.2 # Workaround for https://github.com/python-poetry/poetry/issues/7589
+        run:
+          conda install --channel=conda-forge --quiet --yes gdal=${{
+          env.GDAL_VERSION }} poetry=1.7.1
 
       - name: Install Python packages on non-Windows runner
         run: poetry install --only=main --no-root


### PR DESCRIPTION
Upgrades to 1.8 are [blocked by a Conda issue](https://github.com/conda-forge/poetry-feedstock/issues/101).

~~Blocked by <https://github.com/pypa/pip/pull/11394>, which should be part of the next pip release, >23.2.1.~~