### PR TITLE
feat: Watch more files relevant to Nix shells

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+nix_direnv_watch_file nix ./*.nix ./*/*.nix ./*/*/*.nix ./*/*/poetry.lock ./*/*/pyproject.toml
 use nix

--- a/flooding/sentinel1_water_extraction/.envrc
+++ b/flooding/sentinel1_water_extraction/.envrc
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+nix_direnv_watch_file ../../nix ./*.nix ./poetry.lock ./pyproject.toml
 use nix

--- a/flooding/sentinel2_water_extraction/.envrc
+++ b/flooding/sentinel2_water_extraction/.envrc
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+nix_direnv_watch_file ../../nix ./*.nix ./poetry.lock ./pyproject.toml
 use nix

--- a/machine-readable-to-human-readable-date-time/.envrc
+++ b/machine-readable-to-human-readable-date-time/.envrc
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+nix_direnv_watch_file ../nix
 use nix


### PR DESCRIPTION
`shell.nix` files are watched automatically, but everything else that's an input to the shell needs to be watched explicitly to avoid having to run `direnv reload` manually.