### PR TITLE
feat: Implement stable path to Python interpreter in direnv 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
 use nix
+ln --force --no-target-directory --symbolic "$(which python)" python

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /.mypy_cache/
 *.pyc
 /_site
-.venv
+/python

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,6 @@ exclude:
   - .github/
   - .gitignore
   - .idea/
-  - .venv
   - CODING.md
   - LICENSE
   - README.md
@@ -24,4 +23,5 @@ exclude:
   - machine-readable-to-human-readable-date-time/test
   - nix
   - pyproject.toml
+  - python
   - shell.nix

--- a/shell.nix
+++ b/shell.nix
@@ -51,6 +51,6 @@ in
     ];
 
     shellHook = ''
-      ln --force --no-target-directory --symbolic "${python}" .venv
+      ln --force --no-target-directory --symbolic "${python}/bin/python" python
     '';
   }


### PR DESCRIPTION
direnv does not run the `shellHook`, so we need a separate mechanism to
make sure the Python interpreter is available for example to IDEs.