### PR TITLE
feat: Install setuptools

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ let
         ps:
           [
             ps.mypy
+            ps.pip
             ps.pylint
             ps.types-python-dateutil
           ]


### PR DESCRIPTION
Necessary for JetBrains IDEA to detect Python packages: <https://youtrack.jetbrains.com/issue/PY-58418/Python-packaging-tools-not-found# focus=Comments-27-7857731.0-0>.