### PR TITLE
test: Run only against oldest and latest supported Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,8 +104,6 @@ jobs:
           - windows-2022
         python:
           - "3.8"
-          - "3.9"
-          - "3.10"
           - "3.11"
         sentinel:
           - "1"


### PR DESCRIPTION
About 1/3rd of Conda installs are broken, so this should halve the risk of a broken pipeline without increasing the risk of version incompatibility too much.