### PR TITLE
build: Install Poetry with pipx

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,7 @@ jobs:
           env.GDAL_VERSION }}
 
       - name: Install Poetry
-        run: pipx install poetry==1.7.1
+        run: pipx install poetry==1.8.3
 
       - name: Install Python packages on non-Windows runner
         run: poetry install --only=main --no-root

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,10 +155,13 @@ jobs:
           channels: conda-forge
           python-version: ${{ matrix.python }}
 
-      - name: Install Conda environment packages
+      - name: Install GDAL
         run:
           conda install --channel=conda-forge --quiet --yes gdal=${{
-          env.GDAL_VERSION }} poetry=1.7.1
+          env.GDAL_VERSION }}
+
+      - name: Install Poetry
+        run: pipx install poetry==1.7.1
 
       - name: Install Python packages on non-Windows runner
         run: poetry install --only=main --no-root


### PR DESCRIPTION
build: Install Poetry with pipx

As [recommended by the documentation](https://python-poetry.org/docs/#ci-recommendations) and
[@xylar](https://github.com/conda-forge/poetry-feedstock/issues/101#issuecomment-2113996440).
This should avoid the "No such file or directory:
'/usr/local/miniconda/envs/test/lib/python3.[…]/site-packages/[…].dist-info'"
errors which probably comes from the interaction between Conda and Poetry.
